### PR TITLE
gulp test

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const gulp = require('gulp');
+const mocha = require('gulp-mocha');
+
+const server = require('./test/testServer');
+
+const startServer = done => {
+    server.wait(() => done());
+};
+
+// create server as a dependency of test
+gulp.task('test:server', done => startServer(done));
+
+gulp.task('test', ['test:server'], () => gulp.src('./test/**/*.js')
+  .pipe(mocha({ reporter: 'spec' }))
+  // ensure server is killed
+  .on('end', () => process.exit()));

--- a/index.js
+++ b/index.js
@@ -1,20 +1,3 @@
 "use strict";
 
-const Glue = require('glue');
-const manifest = require('./Config/glue.manifest.json');
-const options = {
-    relativeTo: __dirname + '/Plugins'
-};
-
-Glue.compose(manifest, options, function (err, server) {
-    server.start(function (err) {
-
-        // API running on port 3000
-
-        if (err) {
-            throw err;
-        }
-        console.log('Server running at:', server.info.uri);
-
-    });
-});
+require('./server')();

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "mocha": "^2.5.3",
-    "sinon": "^1.17.5"
+    "sinon": "^1.17.5",
+    "gulp": "^3.9.1",
+    "gulp-mocha": "^2.2.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,25 @@
+"use strict";
+
+const Glue = require('glue');
+const manifest = require('./Config/glue.manifest.json');
+const options = {
+    relativeTo: __dirname + '/Plugins'
+};
+
+module.exports = callback => {
+    Glue.compose(manifest, options, function (err, server) {
+        server.start(function (err) {
+
+            // API running on port 3000
+
+            if (err) {
+                throw err;
+            }
+            console.log('Server running at:', server.info.uri);
+
+            if (callback) {
+                callback(server);
+            }
+        });
+    });
+};

--- a/test/scraper/exampleTest.js
+++ b/test/scraper/exampleTest.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const sinon = require('sinon');
+const server = require('../testServer');
+const scraperFacade = require('../../Plugins/Scraper/services/scraperFacade');
+
+describe('example desc', () => {
+
+    let sandbox = null;
+
+    beforeEach(function () {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    it('example test', done => {
+        
+        sandbox.stub(scraperFacade, 'isVirginAvailable', function() { return Promise.resolve(true); });
+
+        const options = {
+            method: 'GET',
+            url: '/api/virginAvailability?postcode=NE359HD&addressLine1=test&addressLine2=test&city=newcastle',
+            headers: {
+                'Content-Type': 'application/json',
+                Accept: 'application/json'
+            }
+        };
+
+        server.inject(options, res => {
+            console.log(res.statusCode);
+            console.log(res.payload);
+            done();
+        });
+    });
+});

--- a/test/testServer.js
+++ b/test/testServer.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const serverFactory = require('../server');
+
+let server = null;
+
+exports.wait = done => {
+    if (server && server.info.started > 0) {
+        return done();
+    }
+
+    return serverFactory(serverInstance => {
+        server = serverInstance;
+        done();
+    });
+};
+
+exports.instance = () => server;
+
+// Proxy server methods to instance
+[
+    'inject',
+    'table',
+    'route',
+    'ext'
+].forEach(method => {
+    exports[method] = function() {
+        // eslint-disable-next-line prefer-rest-params
+        return server[method].apply(server, arguments);
+    };
+});


### PR DESCRIPTION
run tests with `gulp test`

moved `index.js` to `server.js` so that it now becomes a factory method that takes in a callback
`testServer.js` uses this callback to set a local server var.
`testServer.js` then proxies a select few method of server to expose (inject, table, route, ext)

the gulp task creates the server, runs the tests then destroys the process