### PR TITLE
Error handling improved for V2 scraper

### DIFF
--- a/Plugins/ScraperV2/handler.js
+++ b/Plugins/ScraperV2/handler.js
@@ -6,6 +6,7 @@
 
 const scraperFacade = require('./services/scraperFacades')
 
+// deprecated
 exports.partners = function (request, reply) {
   const postcode = request.query.postcode
   const addressLine1 = request.query.addressLine1
@@ -26,6 +27,7 @@ exports.partners = function (request, reply) {
   })
 }
 
+// deprecated
 exports.partnersCached = function (server) {
   const hapiServer = server
 
@@ -68,10 +70,9 @@ exports.allYours = function (request, reply) {
     if (err.isVirginAvailable === false) {
        return reply(err).code(200)
     }
-    return reply(
-      err.message || 
-      `Something went wrong`
-    ).code(500)
+    return reply({
+      error: err.message || `Something went wrong`
+    }).code(500)
   })
 }
 
@@ -93,10 +94,9 @@ exports.allYoursCached = function (server) {
       if (err === null) {
         return reply(result).code(200)
       }
-      return reply(
-        err.message || 
-        `Something went wrong`
-      ).code(500)
+      return reply({
+        error: err.message || `Something went wrong`
+      }).code(500)
     })
   }
 }
@@ -113,10 +113,9 @@ exports.addresses = function (request, reply) {
     if (err.addresses) {
        return reply(err).code(200)
     }
-    return reply(
-      err.message || 
-      `Something went wrong`
-    ).code(500)
+    return reply({
+      error: err.message || `Something went wrong`
+    }).code(500)
   })
 }
 
@@ -131,10 +130,9 @@ exports.addressesCached = function (server) {
       if (err === null) {
         return reply(result).code(200)
       }
-      return reply(
-        err.message || 
-        `Something went wrong`
-      ).code(500)
+      return reply({
+        error: err.message || `Something went wrong`
+      }).code(500)
     })
   }
 }

--- a/Plugins/ScraperV2/scrapers/addresses.scraper.js
+++ b/Plugins/ScraperV2/scrapers/addresses.scraper.js
@@ -30,7 +30,6 @@ module.exports.scrape = function (postcode) {
         return true
       })
       .evaluate(function () {
-          // es6 syntax doesnt work inside horseman functions
         const addresses = []
 
         $('select[name="chosenAddress"] option').each(function (index, el) {
@@ -47,7 +46,13 @@ module.exports.scrape = function (postcode) {
         return horseman.close().then(_ => resolve({addresses}))
       })
       .catch(function (error) {
-        return horseman.close().then(_ => reject({addresses: []}))
+        return horseman.close().then(_ => {
+          if (error.message === 'no addresses found' ||
+              error.message === 'invalid postcode') {
+                reject({addresses: []})
+          }
+          reject(error)
+        })
       })
   })
 }

--- a/Plugins/ScraperV2/scrapers/allyours.scraper.js
+++ b/Plugins/ScraperV2/scrapers/allyours.scraper.js
@@ -133,7 +133,12 @@ module.exports.scrape = function (postcode, address) {
                     virginData: result}))
                 })
       })
-      .catch(error => horseman.close().then(_ => reject({isVirginAvailable,
-        virginData: {}})))
+      .catch(error => horseman.close().then(_ => {
+        if (error.message === 'unable to find address' ||
+            error.message === 'invalid postcode') {
+          reject({isVirginAvailable, virginData: {}}) 
+        }
+        reject(error)
+      }))
   })
 }


### PR DESCRIPTION
- Timeouts / unhandled rejections are returned as { error: 'message' } with a 500
- Timeouts / unhandled rejections results are NOT cached